### PR TITLE
Add event.persist method

### DIFF
--- a/index.js
+++ b/index.js
@@ -69,6 +69,10 @@ function findReactProps(component) {
 }
 
 function dispatchEvent(event, eventType, componentProps) {
+    event.persist = function() {
+        event.isPersistent = function(){ return true};
+    };
+
     if (componentProps[eventType]) {
         componentProps[eventType](event);
     }


### PR DESCRIPTION
https://reactjs.org/docs/events.html
> If you want to access the event properties in an asynchronous way, you should call event.persist() on the event, which will remove the synthetic event from the pool and allow references to the event to be retained by user code.
> 

Without this fix im getting 'e.persist' is not a function using react-md library's SelectInput onChange 