### PR TITLE
fix: change to use __reactEventHandlersXXX to get latest event handler

### DIFF
--- a/index.js
+++ b/index.js
@@ -31,8 +31,15 @@ module.exports = function retargetEvents(shadowRoot) {
             for (var i = 0; i < path.length; i++) {
 
                 var el = path[i];
+                var props = null;
                 var reactComponent = findReactComponent(el);
-                var props = findReactProps(reactComponent);
+                var eventHandlers = findReactEventHandlers(el);
+
+                if (!eventHandlers) {
+                    props = findReactProps(reactComponent);
+                } else {
+                    props = eventHandlers;
+                }
 
                 if (reactComponent && props) {
                     dispatchEvent(event, reactEventName, props);
@@ -66,9 +73,17 @@ module.exports = function retargetEvents(shadowRoot) {
     };
 };
 
+function findReactEventHandlers(item) {
+    return findReactProperty(item, '__reactEventHandlers');
+}
+
 function findReactComponent(item) {
+    return findReactProperty(item, '_reactInternal');
+}
+
+function findReactProperty(item, propertyPrefix) {
     for (var key in item) {
-        if (item.hasOwnProperty(key) && key.indexOf('_reactInternal') !== -1) {
+        if (item.hasOwnProperty(key) && key.indexOf(propertyPrefix) !== -1) {
             return item[key];
         }
     }


### PR DESCRIPTION
Found an issue when using useState hook (React 16.8.2).
The event handler inside memoizedProps is not updated synchronously, as a result, it's using an old scope which is using the old state value.
Change to use the handlers in __reactEventHandlers from React.js ver 16.0.0, which seems to be updated every time.

Will do more test later.
Raise a pull request first, in case any one has the same issue.

Other findings:
If render react app to this.shadowRoot, we don't need to use this package.
Events are working in React 16.8.2.
But if adding a div to this.shadowRoot and render react app into it, still need this package to retarget react events.