### PR TITLE
Add onMouseLeave degraded support

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,24 @@ const proto = Object.create(HTMLElement.prototype, {
 });
 document.registerElement('my-custom-element', {prototype: proto});
 ```
+
+## Degraded behaviors
+### onMouseLeave
+Since [`onMouseLeave` does not bubble](https://developer.mozilla.org/en-US/docs/Web/API/Element/mouseleave_event),
+it is impossible to retarget it correctly.
+However, it is possible to send fake `onMouseLeave` events when `onMouseOut` is triggered.
+This behavior will not be 100% identical to the original one, but it could solve some issues.
+To enable this behavior, set the `dispatchDegradedOnMouseLeaveEvents` option (disabled by default):
+
+```jsx
+retargetEvents(
+  shadowRoot,
+  {
+    dispatchDegradedOnMouseLeaveEvents: true
+  }
+);
+```
+
 ## History
 
 * v1.08 Support for cancelBubble and FireFox's composedPath

--- a/index.js
+++ b/index.js
@@ -1,7 +1,7 @@
 var reactEvents = ["onAbort", "onAnimationCancel", "onAnimationEnd", "onAnimationIteration", "onAuxClick", "onBlur",
     "onChange", "onClick", "onClose", "onContextMenu", "onDoubleClick", "onError", "onFocus", "onGotPointerCapture",
     "onInput", "onKeyDown", "onKeyPress", "onKeyUp", "onLoad", "onLoadEnd", "onLoadStart", "onLostPointerCapture",
-    "onMouseDown", "onMouseMove", "onMouseOut", "onMouseOver", "onMouseUp", "onPointerCancel", "onPointerDown",
+    "onMouseDown", "onMouseMove", "onMouseOut", "onMouseLeave", "onMouseOver", "onMouseUp", "onPointerCancel", "onPointerDown",
     "onPointerEnter", "onPointerLeave", "onPointerMove", "onPointerOut", "onPointerOver", "onPointerUp", "onReset",
     "onResize", "onScroll", "onSelect", "onSelectionChange", "onSelectStart", "onSubmit", "onTouchCancel",
     "onTouchMove", "onTouchStart", "onTransitionCancel", "onTransitionEnd", "onDrag", "onDragEnd", "onDragEnter",
@@ -14,7 +14,8 @@ var divergentNativeEvents = {
 var mimickedReactEvents = {
     onInput: 'onChange',
     onFocusOut: 'onBlur',
-    onSelectionChange: 'onSelect'
+    onSelectionChange: 'onSelect',
+    onMouseOut: 'onMouseLeave'
 };
 
 module.exports = function retargetEvents(shadowRoot) {

--- a/index.js
+++ b/index.js
@@ -1,7 +1,7 @@
 var reactEvents = ["onAbort", "onAnimationCancel", "onAnimationEnd", "onAnimationIteration", "onAuxClick", "onBlur",
     "onChange", "onClick", "onClose", "onContextMenu", "onDoubleClick", "onError", "onFocus", "onGotPointerCapture",
     "onInput", "onKeyDown", "onKeyPress", "onKeyUp", "onLoad", "onLoadEnd", "onLoadStart", "onLostPointerCapture",
-    "onMouseDown", "onMouseMove", "onMouseOut", "onMouseLeave", "onMouseOver", "onMouseUp", "onPointerCancel", "onPointerDown",
+    "onMouseDown", "onMouseMove", "onMouseOut", "onMouseOver", "onMouseUp", "onPointerCancel", "onPointerDown",
     "onPointerEnter", "onPointerLeave", "onPointerMove", "onPointerOut", "onPointerOver", "onPointerUp", "onReset",
     "onResize", "onScroll", "onSelect", "onSelectionChange", "onSelectStart", "onSubmit", "onTouchCancel",
     "onTouchMove", "onTouchStart", "onTransitionCancel", "onTransitionEnd", "onDrag", "onDragEnd", "onDragEnter",
@@ -11,14 +11,22 @@ var divergentNativeEvents = {
     onDoubleClick: 'dblclick'
 };
 
-var mimickedReactEvents = {
+var defaultMimickedReactEvents = {
     onInput: 'onChange',
     onFocusOut: 'onBlur',
-    onSelectionChange: 'onSelect',
-    onMouseOut: 'onMouseLeave'
+    onSelectionChange: 'onSelect'
 };
 
-module.exports = function retargetEvents(shadowRoot) {
+var defaultOptions = {
+    dispatchDegradedOnMouseLeaveEvents: false
+};
+
+module.exports = function retargetEvents(shadowRoot, options = defaultOptions) {
+    var mimickedReactEvents = Object.assign({}, defaultMimickedReactEvents);
+    if (options.dispatchDegradedOnMouseLeaveEvents) {
+        mimickedReactEvents.onMouseOut = 'onMouseLeave';
+    }
+
     var removeEventListeners = [];
 
     reactEvents.forEach(function (reactEventName) {


### PR DESCRIPTION
### Original issue
I want to use material-ui inside shadow dom, but Tooltips elements don't work.
This is caused by the lack of `onMouseLeave` support by this library.
And of course, there is not support of this event because [`onMouseLeave` does not bubble](https://developer.mozilla.org/en-US/docs/Web/API/Element/mouseleave_event).

My issue was also mentioned by @prvnsmpth here: https://github.com/mui-org/material-ui/issues/16191

### Solution
I propose to create a `dispatchDegradedOnMouseLeaveEvents` option.
When this option is enabled, we will send fake `onMouseLeave` events when `onMouseOut` is triggered.
This solution makes material ui's Tooltip work, and probably a lot of other components which use the event.
Of course, it does not mimick 100% the correct behavior, but since this event is heavily used in hand with `onMouseOver` to maintain a `hovered` state, it works well.

Here is a demo of my pull request: https://codesandbox.io/embed/react-shadow-dom-retarget-events-onmouseleave-8xl6n
As you can see, it works well, except when we disable `onMouseOver` after being triggered once.

That is why I propose this solution as an option which is disabled by default.