### PR TITLE
fix: Don't dispatch events from disabled components

### DIFF
--- a/index.js
+++ b/index.js
@@ -33,6 +33,10 @@ module.exports = function retargetEvents(shadowRoot) {
                 var el = path[i];
                 var reactComponent = findReactComponent(el);
                 var props = findReactProps(reactComponent);
+                
+                if (el && el.getAttribute && el.getAttribute("disabled") != null) {
+                    return;
+                }
 
                 if (reactComponent && props) {
                     dispatchEvent(event, reactEventName, props);


### PR DESCRIPTION
# Problem
Events from disabled elements are dispatched. E.g a disabled button.

# Solution
Stop disabled elements from reaching the dispatch.